### PR TITLE
fixed highlighting issue in stylesheet, and removed config warning

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -73,7 +73,7 @@ sass:
   style: :expanded # You might prefer to minify using :compressed
 
 # Use the following plug-ins
-gems:
+plugins:
   - jekyll-sitemap # Create a sitemap using the official Jekyll sitemap gem
   - jekyll-feed # Create an Atom feed using the official Jekyll feed gem
 

--- a/_sass/_highlights.scss
+++ b/_sass/_highlights.scss
@@ -1,5 +1,5 @@
 
-.highlight {
+pre.highlight {
   background-color: #efefef;
   padding: 7px 7px 7px 10px;
   border: 1px solid #ddd;
@@ -7,7 +7,7 @@
   -webkit-box-shadow: 3px 3px rgba(0,0,0,0.1);
   box-shadow: 3px 3px rgba(0,0,0,0.1);
   margin: 20px 0 20px 0;
-  overflow: scroll;
+  overflow: auto;
 }
 
 code {


### PR DESCRIPTION
Fixed a couple bugs:

- warning due to changed name (`gems` -> `plugins`)
- bad rendering of code blocks (see [here](https://github.com/barryclark/jekyll-now/issues/1223))